### PR TITLE
feat: track dev uuid if NODE_ENV is not set to production.

### DIFF
--- a/src/services/widgetTemplate/track.ts
+++ b/src/services/widgetTemplate/track.ts
@@ -1,9 +1,8 @@
 import { readFileSync, writeFileSync } from 'fs';
 
 import { log } from '../../messages';
-
-const filePath = (dir: string): string => `${dir}/widget.yml`;
-
+const isDev = process.env.NODE_ENV !== 'production';
+const filePath = (dir: string): string => `${dir}/widget${isDev ? '-dev' : ''}.yml`;
 const isTracked = (dir: string): string | null => {
     try {
         const data = readFileSync(filePath(dir), 'utf-8');


### PR DESCRIPTION
## What? Why?
Allow tracking multiple UUIDs for different environments.

If NODE_ENV is set to `production`, the UUID will be loaded from `widget.yml`. If not, the UUID will be loaded from `widget-dev.yml`. This allows tracking both development and production UUIDs in a git repo.

